### PR TITLE
feat: support named imports for json modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	},
 	"dependencies": {
 		"@esbuild-kit/cjs-loader": "^1.0.0",
-		"@esbuild-kit/esm-loader": "^1.0.0"
+		"@esbuild-kit/esm-loader": "^1.1.0"
 	},
 	"optionalDependencies": {
 		"fsevents": "~2.3.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@esbuild-kit/cjs-loader': ^1.0.0
-  '@esbuild-kit/esm-loader': ^1.0.0
+  '@esbuild-kit/esm-loader': ^1.1.0
   '@pvtnbr/eslint-config': ^0.22.0
   '@types/cross-spawn': ^6.0.2
   '@types/node': ^17.0.31
@@ -21,7 +21,7 @@ specifiers:
 
 dependencies:
   '@esbuild-kit/cjs-loader': 1.0.0
-  '@esbuild-kit/esm-loader': 1.0.0
+  '@esbuild-kit/esm-loader': 1.1.0
 
 optionalDependencies:
   fsevents: 2.3.2
@@ -78,10 +78,16 @@ packages:
       esbuild: 0.14.38
     dev: false
 
-  /@esbuild-kit/esm-loader/1.0.0:
-    resolution: {integrity: sha512-fZtvhHmO0fKNHszwb9GtBr4eaBA4ZAPxDpV/oWLh0R45IgMNz7lDIGeqsDHFTwQ4LeFgOMjzRIH0JapX8FUQmQ==}
+  /@esbuild-kit/core-utils/1.0.1:
+    resolution: {integrity: sha512-N9fE4afacf4+82Xygmoa5IXASoPHHPL/OF3E5OaDVWtdoi1rk3StLGV6Vl7rqFSJCetghho/O1jvU/VnMf2pLw==}
     dependencies:
-      '@esbuild-kit/core-utils': 1.0.0
+      esbuild: 0.14.38
+    dev: false
+
+  /@esbuild-kit/esm-loader/1.1.0:
+    resolution: {integrity: sha512-EoEChLvXMAg/PXzUscMHxPjMM6kUWr0fcWuMchis+TxCGPPtpg5XQrO29HbLvP1uw/4AE+aZcfmRgVykGi6gPQ==}
+    dependencies:
+      '@esbuild-kit/core-utils': 1.0.1
       es-module-lexer: 0.10.5
       get-tsconfig: 3.0.1
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,14 +68,8 @@ packages:
   /@esbuild-kit/cjs-loader/1.0.0:
     resolution: {integrity: sha512-6oPhu5QcuTsU5nO3hBCd6OdfeaGsheU6OZrQSAzBsXOiZQ+lB2Zy1bAeAPKqzVGz16kBbheW+OuL54gLD79HdA==}
     dependencies:
-      '@esbuild-kit/core-utils': 1.0.0
+      '@esbuild-kit/core-utils': 1.0.1
       get-tsconfig: 3.0.1
-    dev: false
-
-  /@esbuild-kit/core-utils/1.0.0:
-    resolution: {integrity: sha512-OpBaYYkCxIFnTjk46dYaZplHrLXkYZvw0FporqTEPEWNJV8k2/+LTIZ1U49NdEBB33A3Ke/78KG78EoDnLENcg==}
-    dependencies:
-      esbuild: 0.14.38
     dev: false
 
   /@esbuild-kit/core-utils/1.0.1:

--- a/tests/specs/json.ts
+++ b/tests/specs/json.ts
@@ -3,8 +3,6 @@ import type { NodeApis } from '../utils/tsx';
 
 export default testSuite(async ({ describe }, node: NodeApis) => {
 	describe('Load JSON', ({ describe }) => {
-		const output = '{"loaded":"json"}';
-
 		describe('full path', ({ test }) => {
 			const importPath = './lib/json/index.json';
 
@@ -16,13 +14,13 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 
 			test('Import', async () => {
 				const nodeProcess = await node.import(importPath);
-				expect(nodeProcess.stdout).toBe(`{"default":${output}}`);
+				expect(nodeProcess.stdout).toBe('{"default":{"loaded":"json"},"loaded":"json"}');
 				expect(nodeProcess.stderr).toBe('');
 			});
 
 			test('Require', async () => {
 				const nodeProcess = await node.require(importPath);
-				expect(nodeProcess.stdout).toBe(output);
+				expect(nodeProcess.stdout).toBe('{"loaded":"json"}');
 				expect(nodeProcess.stderr).toBe('');
 			});
 		});
@@ -38,13 +36,13 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 
 			test('Import', async () => {
 				const nodeProcess = await node.import(importPath);
-				expect(nodeProcess.stdout).toBe(`{"default":${output}}`);
+				expect(nodeProcess.stdout).toBe('{"default":{"loaded":"json"},"loaded":"json"}');
 				expect(nodeProcess.stderr).toBe('');
 			});
 
 			test('Require', async () => {
 				const nodeProcess = await node.require(importPath);
-				expect(nodeProcess.stdout).toBe(output);
+				expect(nodeProcess.stdout).toBe('{"loaded":"json"}');
 				expect(nodeProcess.stderr).toBe('');
 			});
 		});
@@ -60,13 +58,13 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 
 			test('Import', async () => {
 				const nodeProcess = await node.import(importPath);
-				expect(nodeProcess.stdout).toBe(`{"default":${output}}`);
+				expect(nodeProcess.stdout).toBe('{"default":{"loaded":"json"},"loaded":"json"}');
 				expect(nodeProcess.stderr).toBe('');
 			});
 
 			test('Require', async () => {
 				const nodeProcess = await node.require(importPath);
-				expect(nodeProcess.stdout).toBe(output);
+				expect(nodeProcess.stdout).toBe('{"loaded":"json"}');
 				expect(nodeProcess.stderr).toBe('');
 			});
 		});


### PR DESCRIPTION
## Problem
Tests are outdated for JSON named imports

## Changes
- Updates semver range floor for `esm-loader`
- Updates tests to support JSON named imports

## Other info
This doesn't necessarily have to be a `feat` because this feature in `esm-loader` is included the range, but figured why not to make the feature definitely installable.
