### PR TITLE
fix: expose `cli` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"dist"
 	],
 	"exports": {
+		"./cli": "./dist/cli.js",
 		"./repl": "./dist/repl.js"
 	},
 	"bin": "./dist/cli.js",


### PR DESCRIPTION
fix https://github.com/esbuild-kit/esno/issues/29