### PR TITLE
fix(repl): specify ts loader

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -14,7 +14,7 @@ const nodeRepl = repl.start();
 const { eval: defaultEval } = nodeRepl;
 
 const preEval: REPLEval = async function (code, context, filename, callback) {
-	const transformed = await transform(code, '.ts').catch(
+	const transformed = await transform(code, 'repl.ts').catch(
 		(error) => {
 			console.log(error.message);
 			return { code: '\n' };

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -14,7 +14,11 @@ const nodeRepl = repl.start();
 const { eval: defaultEval } = nodeRepl;
 
 const preEval: REPLEval = async function (code, context, filename, callback) {
-	const transformed = await transform(code, 'repl.ts').catch(
+	const transformed = await transform(
+		code,
+		filename,
+		{ loader: 'ts' },
+	).catch(
 		(error) => {
 			console.log(error.message);
 			return { code: '\n' };

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -42,6 +42,7 @@ const nodeVersions = [
 					import('./specs/watch'),
 					fixture.path,
 				);
+				runTestSuite(import('./specs/repl'));
 			});
 
 			for (const nodeVersion of nodeVersions) {

--- a/tests/specs/repl.ts
+++ b/tests/specs/repl.ts
@@ -1,0 +1,34 @@
+import { testSuite } from 'manten';
+import { tsx } from '../utils/tsx';
+
+export default testSuite(async ({ describe }) => {
+	describe('repl', ({ test }) => {
+		test('handles ts', async () => {
+			const tsxProcess = tsx({
+				args: [],
+			});
+
+			const commands = [
+				'const message: string = "SUCCESS"',
+				'message',
+			];
+
+			await new Promise<void>((resolve) => {
+				tsxProcess.stdout!.on('data', (data: Buffer) => {
+					const chunkString = data.toString();
+
+					if (chunkString.includes('SUCCESS')) {
+						return resolve();
+					}
+
+					if (chunkString.includes('> ') && commands.length > 0) {
+						const command = commands.shift();
+						tsxProcess.stdin?.write(`${command}\n`);
+					}
+				});
+			});
+
+			tsxProcess.kill();
+		}, 5000);
+	});
+});


### PR DESCRIPTION
# Problem
TypeScript REPL can't actually execute TypeScript expressions
# Reason
It detected a wrong loader(`js`) because in [core-utils](https://github.com/esbuild-kit/core-utils/blob/7348ce37265de7b76be726b9c4e6e335e65be6c0/src/transform/get-esbuild-options.ts#L35) that `path.extname('.ts')` returns an empty string, so it will add a `.js` suffix to the `filePath`and then a `js` loader is detected.

see [transform/get-esbuild-options.ts#L35](https://github.com/esbuild-kit/core-utils/blob/7348ce37265de7b76be726b9c4e6e335e65be6c0/src/transform/get-esbuild-options.ts#L35)

<img width="425" alt="image" src="https://user-images.githubusercontent.com/30516060/175345980-6e8464ed-5b6f-4da1-afa3-1d3701c9ebef.png">
there's also another solution I prefer:

```js
transform(code, 'repl', { loader: 'ts' })
```