### PR TITLE
feat: add `package.json` subpath export

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"dist"
 	],
 	"exports": {
+		"./package.json": "./package.json",
 		".": "./dist/loader.js",
 		"./cli": "./dist/cli.js",
 		"./suppress-warnings": "./dist/suppress-warnings.cjs",


### PR DESCRIPTION
Like use :

```ts
  require.resolve('tsx/package.json')
```

Need export `package.json` subpath, otherwise an error will be thrown.

A real example : https://github.com/umijs/umi/pull/9152/files#diff-faa31e153df54d7263fcc895970fea96ab82253e8943d08d85ea22b49338ac0fR53