### PR TITLE
docs: add section on limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,12 @@ No. tsx uses esbuild's [Transform API](https://esbuild.github.io/api/#transform-
 
 No. tsx's integration with Node.js is designed to be seamless so there is no configuration.
 
-### Does it support all TypeScript language features?
+### Does it have any limitations?
 
-Most TypeScript files will "just work", but some less common language features are not supported by esbuild:
+Transformations are handled by esbuild, so it shares the same limitations such as:
 
-- `emitDecoratorMetadata`: decorators can't be used with tsx
+- Compatibility with code executed via `eval()` is not preserved
+- Only certain `tsconfig.json` properties are supported
+- [`emitDecoratorMetadata`](https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata) is not supported 
 
-Refer to the [TypeScript Caveats](https://esbuild.github.io/content-types/#typescript-caveats) section in the esbuild documentation for further details.
+For details, refer to esbuild's [JavaScript caveats](https://esbuild.github.io/content-types/#javascript-caveats) and [TypeScript caveats](https://esbuild.github.io/content-types/#typescript-caveats) documentation.

--- a/README.md
+++ b/README.md
@@ -190,3 +190,9 @@ No. tsx uses esbuild's [Transform API](https://esbuild.github.io/api/#transform-
 ### Does it have a configuration file?
 
 No. tsx's integration with Node.js is designed to be seamless so there is no configuration.
+
+### Does it support all TypeScript language features?
+
+Most TypeScript files will "just work", but some less common language features are not supported:
+
+- `emitDecoratorMetadata`: decorators can't be used with tsx because they aren't supported by esbuild (see [issue #37](https://github.com/esbuild-kit/tsx/issues/37#issuecomment-1159618330))

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ No. tsx's integration with Node.js is designed to be seamless so there is no con
 
 ### Does it support all TypeScript language features?
 
-Most TypeScript files will "just work", but some less common language features are not supported:
+Most TypeScript files will "just work", but some less common language features are not supported by esbuild:
 
-- `emitDecoratorMetadata`: decorators can't be used with tsx because they aren't supported by esbuild (see [issue #37](https://github.com/esbuild-kit/tsx/issues/37#issuecomment-1159618330))
+- `emitDecoratorMetadata`: decorators can't be used with tsx
+
+Refer to the [TypeScript Caveats](https://esbuild.github.io/content-types/#typescript-caveats) section in the esbuild documentation for further details.


### PR DESCRIPTION
I wanted to :heart: tsx, but the lack of support for decorators (see #37) is a significant and unfortunate blocker.

I spent some effort testing a NestJs project with tsx and debugging why it didn't work before I learned this fact. Having this information available from the start would have saved me some time, so for the benefit of others I suggest adding it to the project README.