### PR TITLE
fix(watch): relative paths in --ignore flag

### DIFF
--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -118,6 +118,7 @@ export const watchCommand = command({
 	const watcher = watch(
 		argv._,
 		{
+			cwd: process.cwd(),
 			ignoreInitial: true,
 			ignored: [
 				// Hidden directories like .git

--- a/tests/specs/watch.ts
+++ b/tests/specs/watch.ts
@@ -161,12 +161,13 @@ export default testSuite(async ({ describe }, fixturePath: string) => {
 				});
 
 				const tsxProcess = tsx({
+					cwd: fixture.path,
 					args: [
 						'watch',
 						'--clear-screen=false',
-						`--ignore=${path.join(fixture.path, fileA)}`,
-						`--ignore=${path.join(fixture.path, 'directory/*')}`,
-						path.join(fixture.path, entryFile),
+						`--ignore=${fileA}`,
+						'--ignore=directory/*',
+						entryFile,
 					],
 				});
 

--- a/tests/specs/watch.ts
+++ b/tests/specs/watch.ts
@@ -166,7 +166,7 @@ export default testSuite(async ({ describe }, fixturePath: string) => {
 						'watch',
 						'--clear-screen=false',
 						`--ignore=${fileA}`,
-						'--ignore=directory/*',
+						`--ignore=${path.join(fixture.path, 'directory/*')}`,
 						entryFile,
 					],
 				});


### PR DESCRIPTION
When using relative paths with `watch --ignore`, chokidar won't pick up the correct files.

The existing test is refactored to use relative paths instead of absolute paths to ignore and execute. 

The fix is to explicitly provide a `cwd` to chokidar.

**Reproduction**: open [stackblitz](stackblitz.com/edit/node-q34cum?file=index.js&view=editor), run `pnpm dev` and change something in `ignored.js`. `tsx` should not rerun, but does.