### PR TITLE
refactor: patch Node.js REPL to add TypeScript support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,9 +51,6 @@ cli({
 			});
 			return;
 		}
-
-		// Load REPL
-		process.argv.push(require.resolve('./repl'));
 	}
 
 	const args = typeFlag(

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,4 +1,6 @@
 // Hook require() to transform to CJS
+import './patch-repl';
+
 require('@esbuild-kit/cjs-loader');
 
 /*

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,6 +1,6 @@
-// Hook require() to transform to CJS
 import './patch-repl';
 
+// Hook require() to transform to CJS
 require('@esbuild-kit/cjs-loader');
 
 /*

--- a/src/patch-repl.ts
+++ b/src/patch-repl.ts
@@ -1,0 +1,42 @@
+import repl, { type REPLServer, type REPLEval } from 'repl';
+import { transform } from '@esbuild-kit/core-utils';
+
+function patchEval(nodeRepl: REPLServer) {
+	const { eval: defaultEval } = nodeRepl;
+	const preEval: REPLEval = async function (code, context, filename, callback) {
+		const transformed = await transform(
+			code,
+			filename,
+			{
+				loader: 'ts',
+				tsconfigRaw: {
+					compilerOptions: {
+						preserveValueImports: true,
+					},
+				},
+				define: {
+					require: 'global.require',
+				},
+			},
+		).catch(
+			(error) => {
+				console.log(error.message);
+				return { code: '\n' };
+			},
+		);
+
+		return defaultEval.call(this, transformed.code, context, filename, callback);
+	};
+
+	// @ts-expect-error overwriting read-only property
+	nodeRepl.eval = preEval;
+}
+
+const { start } = repl;
+repl.start = function () {
+	const nodeRepl = Reflect.apply(start, this, arguments);
+	patchEval(nodeRepl);
+	return nodeRepl;
+};
+
+export {};

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1,3 +1,5 @@
+// Deprecated: Delete entry-point in next major in favor of patch-repl.ts
+
 import repl, { type REPLEval } from 'repl';
 import { transform } from '@esbuild-kit/core-utils';
 import { version } from '../package.json';

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -54,18 +54,18 @@ const nodeVersions = [
 						import('./specs/repl'),
 						node,
 					);
-					// runTestSuite(
-					// 	import('./specs/javascript'),
-					// 	node,
-					// );
-					// runTestSuite(
-					// 	import('./specs/typescript'),
-					// 	node,
-					// );
-					// runTestSuite(
-					// 	import('./specs/json'),
-					// 	node,
-					// );
+					runTestSuite(
+						import('./specs/javascript'),
+						node,
+					);
+					runTestSuite(
+						import('./specs/typescript'),
+						node,
+					);
+					runTestSuite(
+						import('./specs/json'),
+						node,
+					);
 				});
 			}
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -10,18 +10,18 @@ const packageTypes = [
 ] as const;
 
 const nodeVersions = [
-	// '12.20.0', // CJS named export detection added
+	'12.20.0', // CJS named export detection added
 	'12.22.11',
-	// ...(
-	// 	(process.env.CI && !isWin)
-	// 		? [
-	// 			'14.19.1',
-	// 			'16.13.2',
-	// 			'17.8.0',
-	// 			'18.0.0',
-	// 		]
-	// 		: []
-	// ),
+	...(
+		(process.env.CI && !isWin)
+			? [
+				'14.19.1',
+				'16.13.2',
+				'17.8.0',
+				'18.0.0',
+			]
+			: []
+	),
 ];
 
 (async () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -42,7 +42,6 @@ const nodeVersions = [
 					import('./specs/watch'),
 					fixture.path,
 				);
-				runTestSuite(import('./specs/repl'));
 			});
 
 			for (const nodeVersion of nodeVersions) {
@@ -51,6 +50,10 @@ const nodeVersions = [
 				node.packageType = packageType;
 
 				await describe(`Node ${node.version}`, ({ runTestSuite }) => {
+					runTestSuite(
+						import('./specs/repl'),
+						node,
+					);
 					runTestSuite(
 						import('./specs/javascript'),
 						node,

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -10,18 +10,18 @@ const packageTypes = [
 ] as const;
 
 const nodeVersions = [
-	'12.20.0', // CJS named export detection added
+	// '12.20.0', // CJS named export detection added
 	'12.22.11',
-	...(
-		(process.env.CI && !isWin)
-			? [
-				'14.19.1',
-				'16.13.2',
-				'17.8.0',
-				'18.0.0',
-			]
-			: []
-	),
+	// ...(
+	// 	(process.env.CI && !isWin)
+	// 		? [
+	// 			'14.19.1',
+	// 			'16.13.2',
+	// 			'17.8.0',
+	// 			'18.0.0',
+	// 		]
+	// 		: []
+	// ),
 ];
 
 (async () => {
@@ -54,18 +54,18 @@ const nodeVersions = [
 						import('./specs/repl'),
 						node,
 					);
-					runTestSuite(
-						import('./specs/javascript'),
-						node,
-					);
-					runTestSuite(
-						import('./specs/typescript'),
-						node,
-					);
-					runTestSuite(
-						import('./specs/json'),
-						node,
-					);
+					// runTestSuite(
+					// 	import('./specs/javascript'),
+					// 	node,
+					// );
+					// runTestSuite(
+					// 	import('./specs/typescript'),
+					// 	node,
+					// );
+					// runTestSuite(
+					// 	import('./specs/json'),
+					// 	node,
+					// );
 				});
 			}
 

--- a/tests/specs/repl.ts
+++ b/tests/specs/repl.ts
@@ -33,54 +33,54 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			tsxProcess.kill();
 		}, 10000);
 
-		test('doesn\'t error on require', async () => {
-			const tsxProcess = node.tsx({
-				args: ['--interactive'],
-			});
+		// test('doesn\'t error on require', async () => {
+		// 	const tsxProcess = node.tsx({
+		// 		args: ['--interactive'],
+		// 	});
 
-			await new Promise<void>((resolve, reject) => {
-				tsxProcess.stdout!.on('data', (data: Buffer) => {
-					const chunkString = data.toString();
-					console.log({ chunkString });
+		// 	await new Promise<void>((resolve, reject) => {
+		// 		tsxProcess.stdout!.on('data', (data: Buffer) => {
+		// 			const chunkString = data.toString();
+		// 			console.log({ chunkString });
 
-					if (chunkString.includes('unsupported-require-call')) {
-						return reject(chunkString);
-					}
+		// 			if (chunkString.includes('unsupported-require-call')) {
+		// 				return reject(chunkString);
+		// 			}
 
-					if (chunkString.includes('[Function: resolve]')) {
-						return resolve();
-					}
+		// 			if (chunkString.includes('[Function: resolve]')) {
+		// 				return resolve();
+		// 			}
 
-					if (chunkString.includes('> ')) {
-						tsxProcess.stdin?.write('require("path")\r');
-					}
-				});
-			});
+		// 			if (chunkString.includes('> ')) {
+		// 				tsxProcess.stdin?.write('require("path")\r');
+		// 			}
+		// 		});
+		// 	});
 
-			tsxProcess.kill();
-		}, 10000);
+		// 	tsxProcess.kill();
+		// }, 10000);
 
-		test('errors on import statement', async () => {
-			const tsxProcess = node.tsx({
-				args: ['--interactive'],
-			});
+		// test('errors on import statement', async () => {
+		// 	const tsxProcess = node.tsx({
+		// 		args: ['--interactive'],
+		// 	});
 
-			await new Promise<void>((resolve) => {
-				tsxProcess.stdout!.on('data', (data: Buffer) => {
-					const chunkString = data.toString();
-					console.log({ chunkString });
+		// 	await new Promise<void>((resolve) => {
+		// 		tsxProcess.stdout!.on('data', (data: Buffer) => {
+		// 			const chunkString = data.toString();
+		// 			console.log({ chunkString });
 
-					if (chunkString.includes('SyntaxError: Cannot use import statement')) {
-						return resolve();
-					}
+		// 			if (chunkString.includes('SyntaxError: Cannot use import statement')) {
+		// 				return resolve();
+		// 			}
 
-					if (chunkString.includes('> ')) {
-						tsxProcess.stdin?.write('import fs from "fs"\r');
-					}
-				});
-			});
+		// 			if (chunkString.includes('> ')) {
+		// 				tsxProcess.stdin?.write('import fs from "fs"\r');
+		// 			}
+		// 		});
+		// 	});
 
-			tsxProcess.kill();
-		}, 10000);
+		// 	tsxProcess.kill();
+		// }, 10000);
 	});
 });

--- a/tests/specs/repl.ts
+++ b/tests/specs/repl.ts
@@ -29,7 +29,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			});
 
 			tsxProcess.kill();
-		}, 20000);
+		}, 20_000);
 
 		test('doesn\'t error on require', async () => {
 			const tsxProcess = node.tsx({
@@ -55,7 +55,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			});
 
 			tsxProcess.kill();
-		}, 20000);
+		}, 20_000);
 
 		test('errors on import statement', async () => {
 			const tsxProcess = node.tsx({
@@ -77,6 +77,6 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			});
 
 			tsxProcess.kill();
-		}, 20000);
+		}, 20_000);
 	});
 });

--- a/tests/specs/repl.ts
+++ b/tests/specs/repl.ts
@@ -24,7 +24,8 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 
 					if (chunkString.includes('> ') && commands.length > 0) {
 						const command = commands.shift();
-						tsxProcess.stdin?.write(`${command}\n`);
+						console.log({ command });
+						tsxProcess.stdin?.write(`${command}\r`);
 					}
 				});
 			});
@@ -51,7 +52,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 					}
 
 					if (chunkString.includes('> ')) {
-						tsxProcess.stdin?.write('require("path")\n');
+						tsxProcess.stdin?.write('require("path")\r');
 					}
 				});
 			});
@@ -74,7 +75,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 					}
 
 					if (chunkString.includes('> ')) {
-						tsxProcess.stdin?.write('import fs from "fs"\n');
+						tsxProcess.stdin?.write('import fs from "fs"\r');
 					}
 				});
 			});

--- a/tests/specs/repl.ts
+++ b/tests/specs/repl.ts
@@ -29,7 +29,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			});
 
 			tsxProcess.kill();
-		}, 20_000);
+		}, 30_000);
 
 		test('doesn\'t error on require', async () => {
 			const tsxProcess = node.tsx({
@@ -55,7 +55,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			});
 
 			tsxProcess.kill();
-		}, 20_000);
+		}, 30_000);
 
 		test('errors on import statement', async () => {
 			const tsxProcess = node.tsx({
@@ -77,6 +77,6 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			});
 
 			tsxProcess.kill();
-		}, 20_000);
+		}, 30_000);
 	});
 });

--- a/tests/specs/repl.ts
+++ b/tests/specs/repl.ts
@@ -17,8 +17,6 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 				tsxProcess.stdout!.on('data', (data: Buffer) => {
 					const chunkString = data.toString();
 
-					console.log({ chunkString });
-
 					if (chunkString.includes('SUCCESS')) {
 						return resolve();
 					}
@@ -41,8 +39,6 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			await new Promise<void>((resolve, reject) => {
 				tsxProcess.stdout!.on('data', (data: Buffer) => {
 					const chunkString = data.toString();
-
-					console.log({ chunkString });
 
 					if (chunkString.includes('unsupported-require-call')) {
 						return reject(chunkString);
@@ -69,8 +65,6 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			await new Promise<void>((resolve) => {
 				tsxProcess.stdout!.on('data', (data: Buffer) => {
 					const chunkString = data.toString();
-
-					console.log({ chunkString });
 
 					if (chunkString.includes('SyntaxError: Cannot use import statement')) {
 						return resolve();

--- a/tests/specs/repl.ts
+++ b/tests/specs/repl.ts
@@ -4,13 +4,8 @@ import { type NodeApis } from '../utils/tsx';
 export default testSuite(async ({ describe }, node: NodeApis) => {
 	describe('repl', ({ test }) => {
 		test('handles ts', async () => {
-			console.log('start', Date.now());
 			const tsxProcess = node.tsx({
 				args: ['--interactive'],
-			});
-
-			tsxProcess.on('spawn', () => {
-				console.log('spawn', Date.now());
 			});
 
 			const commands = [
@@ -21,7 +16,6 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			await new Promise<void>((resolve) => {
 				tsxProcess.stdout!.on('data', (data: Buffer) => {
 					const chunkString = data.toString();
-					console.log({ chunkString }, Date.now());
 
 					if (chunkString.includes('SUCCESS')) {
 						return resolve();
@@ -29,63 +23,60 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 
 					if (chunkString.includes('> ') && commands.length > 0) {
 						const command = commands.shift();
-						console.log({ command }, Date.now());
 						tsxProcess.stdin?.write(`${command}\r`);
 					}
 				});
 			});
 
 			tsxProcess.kill();
-		});
+		}, 20000);
 
-		// test('doesn\'t error on require', async () => {
-		// 	const tsxProcess = node.tsx({
-		// 		args: ['--interactive'],
-		// 	});
+		test('doesn\'t error on require', async () => {
+			const tsxProcess = node.tsx({
+				args: ['--interactive'],
+			});
 
-		// 	await new Promise<void>((resolve, reject) => {
-		// 		tsxProcess.stdout!.on('data', (data: Buffer) => {
-		// 			const chunkString = data.toString();
-		// 			console.log({ chunkString });
+			await new Promise<void>((resolve, reject) => {
+				tsxProcess.stdout!.on('data', (data: Buffer) => {
+					const chunkString = data.toString();
 
-		// 			if (chunkString.includes('unsupported-require-call')) {
-		// 				return reject(chunkString);
-		// 			}
+					if (chunkString.includes('unsupported-require-call')) {
+						return reject(chunkString);
+					}
 
-		// 			if (chunkString.includes('[Function: resolve]')) {
-		// 				return resolve();
-		// 			}
+					if (chunkString.includes('[Function: resolve]')) {
+						return resolve();
+					}
 
-		// 			if (chunkString.includes('> ')) {
-		// 				tsxProcess.stdin?.write('require("path")\r');
-		// 			}
-		// 		});
-		// 	});
+					if (chunkString.includes('> ')) {
+						tsxProcess.stdin?.write('require("path")\r');
+					}
+				});
+			});
 
-		// 	tsxProcess.kill();
-		// }, 10000);
+			tsxProcess.kill();
+		}, 20000);
 
-		// test('errors on import statement', async () => {
-		// 	const tsxProcess = node.tsx({
-		// 		args: ['--interactive'],
-		// 	});
+		test('errors on import statement', async () => {
+			const tsxProcess = node.tsx({
+				args: ['--interactive'],
+			});
 
-		// 	await new Promise<void>((resolve) => {
-		// 		tsxProcess.stdout!.on('data', (data: Buffer) => {
-		// 			const chunkString = data.toString();
-		// 			console.log({ chunkString });
+			await new Promise<void>((resolve) => {
+				tsxProcess.stdout!.on('data', (data: Buffer) => {
+					const chunkString = data.toString();
 
-		// 			if (chunkString.includes('SyntaxError: Cannot use import statement')) {
-		// 				return resolve();
-		// 			}
+					if (chunkString.includes('SyntaxError: Cannot use import statement')) {
+						return resolve();
+					}
 
-		// 			if (chunkString.includes('> ')) {
-		// 				tsxProcess.stdin?.write('import fs from "fs"\r');
-		// 			}
-		// 		});
-		// 	});
+					if (chunkString.includes('> ')) {
+						tsxProcess.stdin?.write('import fs from "fs"\r');
+					}
+				});
+			});
 
-		// 	tsxProcess.kill();
-		// }, 10000);
+			tsxProcess.kill();
+		}, 20000);
 	});
 });

--- a/tests/specs/repl.ts
+++ b/tests/specs/repl.ts
@@ -1,11 +1,11 @@
 import { testSuite } from 'manten';
-import { tsx } from '../utils/tsx';
+import { type NodeApis } from '../utils/tsx';
 
-export default testSuite(async ({ describe }) => {
+export default testSuite(async ({ describe }, node: NodeApis) => {
 	describe('repl', ({ test }) => {
 		test('handles ts', async () => {
-			const tsxProcess = tsx({
-				args: [],
+			const tsxProcess = node.tsx({
+				args: ['--interactive'],
 			});
 
 			const commands = [
@@ -32,8 +32,8 @@ export default testSuite(async ({ describe }) => {
 		}, 5000);
 
 		test('doesn\'t error on require', async () => {
-			const tsxProcess = tsx({
-				args: [],
+			const tsxProcess = node.tsx({
+				args: ['--interactive'],
 			});
 
 			await new Promise<void>((resolve, reject) => {
@@ -58,15 +58,15 @@ export default testSuite(async ({ describe }) => {
 		}, 5000);
 
 		test('errors on import statement', async () => {
-			const tsxProcess = tsx({
-				args: [],
+			const tsxProcess = node.tsx({
+				args: ['--interactive'],
 			});
 
 			await new Promise<void>((resolve) => {
 				tsxProcess.stdout!.on('data', (data: Buffer) => {
 					const chunkString = data.toString();
 
-					if (chunkString.includes('SyntaxError: Cannot use import statement inside the Node.js REPL')) {
+					if (chunkString.includes('SyntaxError: Cannot use import statement')) {
 						return resolve();
 					}
 

--- a/tests/specs/repl.ts
+++ b/tests/specs/repl.ts
@@ -17,6 +17,8 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 				tsxProcess.stdout!.on('data', (data: Buffer) => {
 					const chunkString = data.toString();
 
+					console.log({ chunkString });
+
 					if (chunkString.includes('SUCCESS')) {
 						return resolve();
 					}
@@ -39,6 +41,8 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			await new Promise<void>((resolve, reject) => {
 				tsxProcess.stdout!.on('data', (data: Buffer) => {
 					const chunkString = data.toString();
+
+					console.log({ chunkString });
 
 					if (chunkString.includes('unsupported-require-call')) {
 						return reject(chunkString);
@@ -65,6 +69,8 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			await new Promise<void>((resolve) => {
 				tsxProcess.stdout!.on('data', (data: Buffer) => {
 					const chunkString = data.toString();
+
+					console.log({ chunkString });
 
 					if (chunkString.includes('SyntaxError: Cannot use import statement')) {
 						return resolve();

--- a/tests/specs/repl.ts
+++ b/tests/specs/repl.ts
@@ -16,6 +16,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			await new Promise<void>((resolve) => {
 				tsxProcess.stdout!.on('data', (data: Buffer) => {
 					const chunkString = data.toString();
+					console.log({ chunkString });
 
 					if (chunkString.includes('SUCCESS')) {
 						return resolve();
@@ -39,6 +40,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			await new Promise<void>((resolve, reject) => {
 				tsxProcess.stdout!.on('data', (data: Buffer) => {
 					const chunkString = data.toString();
+					console.log({ chunkString });
 
 					if (chunkString.includes('unsupported-require-call')) {
 						return reject(chunkString);
@@ -65,6 +67,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			await new Promise<void>((resolve) => {
 				tsxProcess.stdout!.on('data', (data: Buffer) => {
 					const chunkString = data.toString();
+					console.log({ chunkString });
 
 					if (chunkString.includes('SyntaxError: Cannot use import statement')) {
 						return resolve();

--- a/tests/specs/repl.ts
+++ b/tests/specs/repl.ts
@@ -29,7 +29,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			});
 
 			tsxProcess.kill();
-		}, 5000);
+		}, 10000);
 
 		test('doesn\'t error on require', async () => {
 			const tsxProcess = node.tsx({
@@ -55,7 +55,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			});
 
 			tsxProcess.kill();
-		}, 5000);
+		}, 10000);
 
 		test('errors on import statement', async () => {
 			const tsxProcess = node.tsx({
@@ -77,6 +77,6 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			});
 
 			tsxProcess.kill();
-		}, 5000);
+		}, 10000);
 	});
 });

--- a/tests/specs/repl.ts
+++ b/tests/specs/repl.ts
@@ -4,8 +4,13 @@ import { type NodeApis } from '../utils/tsx';
 export default testSuite(async ({ describe }, node: NodeApis) => {
 	describe('repl', ({ test }) => {
 		test('handles ts', async () => {
+			console.log('start', Date.now());
 			const tsxProcess = node.tsx({
 				args: ['--interactive'],
+			});
+
+			tsxProcess.on('spawn', () => {
+				console.log('spawn', Date.now());
 			});
 
 			const commands = [
@@ -16,7 +21,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			await new Promise<void>((resolve) => {
 				tsxProcess.stdout!.on('data', (data: Buffer) => {
 					const chunkString = data.toString();
-					console.log({ chunkString });
+					console.log({ chunkString }, Date.now());
 
 					if (chunkString.includes('SUCCESS')) {
 						return resolve();
@@ -24,14 +29,14 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 
 					if (chunkString.includes('> ') && commands.length > 0) {
 						const command = commands.shift();
-						console.log({ command });
+						console.log({ command }, Date.now());
 						tsxProcess.stdin?.write(`${command}\r`);
 					}
 				});
 			});
 
 			tsxProcess.kill();
-		}, 10000);
+		});
 
 		// test('doesn\'t error on require', async () => {
 		// 	const tsxProcess = node.tsx({

--- a/tests/utils/tsx.ts
+++ b/tests/utils/tsx.ts
@@ -55,13 +55,12 @@ export async function createNode(
 				args?: string[];
 			},
 		) {
-			return tsx(
+			return this.tsx(
 				{
 					args: [
 						...(options?.args ?? []),
 						filePath,
 					],
-					nodePath: node.path,
 					cwd: path.join(fixturePath, options?.cwd ?? ''),
 				},
 			);
@@ -72,12 +71,11 @@ export async function createNode(
 				typescript?: boolean;
 			},
 		) {
-			return tsx({
+			return this.tsx({
 				args: [
 					`./import-file${options?.typescript ? '.ts' : '.js'}`,
 					filePath,
 				],
-				nodePath: node.path,
 				cwd: fixturePath,
 			});
 		},
@@ -87,12 +85,11 @@ export async function createNode(
 				typescript?: boolean;
 			},
 		) {
-			return tsx({
+			return this.tsx({
 				args: [
 					`./require-file${options?.typescript ? '.cts' : '.cjs'}`,
 					filePath,
 				],
-				nodePath: node.path,
 				cwd: fixturePath,
 			});
 		},

--- a/tests/utils/tsx.ts
+++ b/tests/utils/tsx.ts
@@ -40,6 +40,14 @@ export async function createNode(
 		get isCJS() {
 			return this.packageType === 'commonjs';
 		},
+		tsx(
+			options: Options,
+		) {
+			return tsx({
+				...options,
+				nodePath: node.path,
+			});
+		},
 		load(
 			filePath: string,
 			options?: {


### PR DESCRIPTION
## Problem
Previously, tsx was creating it's own REPL, which diverged and lacked functionality from Node.js's default REPL. This also required that tsx re-implement flag handling logic to match Node.js.

## Changes
Instead of creating a new REPL, patch Node.js' so that we get Node.js's better REPL for free and also delegate handling the command line flags.

## Other info

Since we are no longer handling how Node.js should interpret command-line flags, this may benefit https://github.com/esbuild-kit/tsx/pull/111