### PR TITLE
fix(watch): remove `dist` from ignore

### DIFF
--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -146,9 +146,6 @@ export const watchCommand = command({
 				// 3rd party packages
 				'**/{node_modules,bower_components,vendor}/**',
 
-				// Distribution files
-				'**/dist/**',
-
 				...options.ignore,
 			],
 			ignorePermissionErrors: true,

--- a/tests/specs/watch.ts
+++ b/tests/specs/watch.ts
@@ -194,7 +194,7 @@ export default testSuite(async ({ describe }, fixturePath: string) => {
 
 				expect(tsxProcessResolved.stdout).not.toMatch(`${value} ${value}`);
 				expect(tsxProcessResolved.stderr).toBe('');
-			}, 5000);
+			}, 10_000);
 		});
 	});
 });


### PR DESCRIPTION
## Problem
`dist` directory was ignored from watch. This made it difficult to pair tsx with programs that built source files.

For example, when developing an ESLint config, ESLint handles loading the config modules, so they must be built to CommonJS. (There's no way to override the default `require` hook because ESLint tries to handle different extensions on its own.) When testing the config, the test files would be importing from the `dist` directory.

## Changes
Remove `dist` from watch ignore list.