### PR TITLE
fix invalid tsconfig.extends under tests

### DIFF
--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,4 +1,4 @@
 {
-	"extends": "..",
+	"extends": "../tsconfig",
 	"include": ["."]
 }


### PR DESCRIPTION
`tsconfig.extends` must point to the base `tsconfig.json`, [possibly using Node.js style resolution](https://www.typescriptlang.org/tsconfig#extends). Pointing to a directory is non-standard way that may work in certain environments but then it stops. (I actually used to do the same earlier until I was hit by the same problem when upgrading the stack.)

For instance, it's not currently possible to build the tests with plain `esbuild`:

```
~/gh/tsx/tests/fixtures/tsconfig/node_modules/should-not-resolve-paths fix/tsconfig_extends*
❯ /Users/semenov/gh/tsx/node_modules/.pnpm/esbuild@0.15.10/node_modules/esbuild/bin/esbuild index.mjs
✘ [ERROR] Cannot read file "../../../../..": is a directory

    ../../../../tsconfig.json:2:12:
      2 │   "extends": "..",
        ╵              ~~~~

1 error
```

It works after the patch:

```
~/gh/tsx/tests/fixtures/tsconfig/node_modules/should-not-resolve-paths fix/tsconfig_extends*
❯ /Users/semenov/gh/tsx/node_modules/.pnpm/esbuild@0.15.10/node_modules/esbuild/bin/esbuild index.mjs
import value from "p/nested-resolve-target";
console.log(value);
```