### PR TITLE
feat: support TypeScript code in eval flag

### DIFF
--- a/tests/specs/cli.ts
+++ b/tests/specs/cli.ts
@@ -69,6 +69,25 @@ export default testSuite(({ describe }, fixturePath: string) => {
 				expect(tsxProcess.stdout).toMatch('hi!!!');
 				expect(tsxProcess.stderr).toBe('');
 			});
+
+			test('works expectedly with --input-type=module', async () => {
+				const tsxProcess = await tsx({
+					args: ['--eval', 'console.log(import.meta.url);', '--input-type=module'],
+				});
+
+				expect(tsxProcess.exitCode).toBe(0);
+				expect(tsxProcess.stdout).toMatch('undefined');
+				expect(tsxProcess.stderr).toBe('');
+			});
+
+			test('fails to access __dirname with --input-type=module', async () => {
+				const tsxProcess = await tsx({
+					args: ['--eval', 'console.log(__dirname);', '--input-type=module'],
+				});
+
+				expect(tsxProcess.exitCode).toBe(1);
+				expect(tsxProcess.stderr).toMatch('ReferenceError: __dirname is not defined in ES module scope');
+			});
 		});
 
 		test('Node.js test runner', async () => {

--- a/tests/specs/cli.ts
+++ b/tests/specs/cli.ts
@@ -59,6 +59,18 @@ export default testSuite(({ describe }, fixturePath: string) => {
 			});
 		});
 
+		describe('eval', ({ test }) => {
+			test('evaluates TypeScript code inside the eval flag', async () => {
+				const tsxProcess = await tsx({
+					args: ['--eval', 'const thing: string = "hi!!!"; console.log(thing);'],
+				});
+
+				expect(tsxProcess.exitCode).toBe(0);
+				expect(tsxProcess.stdout).toMatch('hi!!!');
+				expect(tsxProcess.stderr).toBe('');
+			});
+		});
+
 		test('Node.js test runner', async () => {
 			const tsxProcess = await tsx({
 				args: [


### PR DESCRIPTION
fixes #162 

This PR is my attempt to add support of TypeScript code in the eval flag.
Not sure if it's the correct approach. I've got inspired by the `preEval` function of `repl.ts`, so I tried doing something similar by using `transformSync` from `@esbuild-kit/core-utils`. After transforming it, I tried swapping the original TS code's argv with the transformed code.

There are still several things I'm not sure (e.g. the `filePath` parameter of `transformSync`).
Please guide me if I've done it wrong.