### PR TITLE
fix: hide relaySignal from `process.listeners()`

### DIFF
--- a/src/preflight.cts
+++ b/src/preflight.cts
@@ -45,4 +45,14 @@ if (process.send) {
 		}
 		return count;
 	};
+
+	// Also hide relaySignal from process.listeners()
+	const { listeners } = process;
+	process.listeners = function (eventName) {
+		const result = Reflect.apply(listeners, this, arguments);
+		if (relaySignals.includes(eventName as any)) {
+			return result.filter((listener: any) => listener !== relaySignal);
+		}
+		return result;
+	};
 }


### PR DESCRIPTION
Closes #193 

Continues the approach from #123 and hides the `relaySignal` listener added by tsx from `process.listeners()` which is what the signal-exit module uses to determine whether to proceed with exiting the program. I've tested and confirmed that it fixes the issue.

https://github.com/tapjs/signal-exit/blob/8d4bd9c/index.js#L121