### PR TITLE
fix(cache): scope cache directory to user

### DIFF
--- a/src/utils/transform/cache.ts
+++ b/src/utils/transform/cache.ts
@@ -18,10 +18,10 @@ class FileCache<ReturnType> extends Map<string, ReturnType> {
 	 * https://superuser.com/a/1599897
 	 */
 	cacheDirectory = path.join(
-		// Permissions writable by anyone
+		// Write permissions by anyone
 		os.tmpdir(),
 
-		// Permissions writable by current user
+		// Write permissions only by current user
 		`tsx-${os.userInfo().uid}`,
 	);
 

--- a/src/utils/transform/cache.ts
+++ b/src/utils/transform/cache.ts
@@ -17,7 +17,7 @@ class FileCache<ReturnType> extends Map<string, ReturnType> {
 	 * Note on Windows, temp files are not cleaned up automatically.
 	 * https://superuser.com/a/1599897
 	 */
-	cacheDirectory = path.join(os.tmpdir(), 'tsx');
+	cacheDirectory = path.join(os.tmpdir(), `tsx-${os.userInfo().uid}`);
 
 	cacheFiles: {
 		time: number;

--- a/src/utils/transform/cache.ts
+++ b/src/utils/transform/cache.ts
@@ -17,7 +17,13 @@ class FileCache<ReturnType> extends Map<string, ReturnType> {
 	 * Note on Windows, temp files are not cleaned up automatically.
 	 * https://superuser.com/a/1599897
 	 */
-	cacheDirectory = path.join(os.tmpdir(), `tsx-${os.userInfo().uid}`);
+	cacheDirectory = path.join(
+		// Permissions writable by anyone
+		os.tmpdir(),
+
+		// Permissions writable by current user
+		`tsx-${os.userInfo().uid}`,
+	);
 
 	cacheFiles: {
 		time: number;


### PR DESCRIPTION
If you use `tsx` in a Unix environment where different users are executing `tsx` at the same time, you'll end up trying to share `/tmp/tsx`.

```bash
Error: EACCES: permission denied, scandir '/tmp/tsx'
```

This attempts to resolve that problem by using the executing `uid` in the cache directory name.
Seeing as the unix permissions of the `/tmp/tsx` directory already has the `uid` as meta information, this doesn't reveal anything new, but it does prevent the naming conflict.

```node
> path.join(os.tmpdir(), `tsx-${os.userInfo().uid}`)
'/tmp/tsx-1000'
```

I don't know what behavior this will have on non-unix systems
